### PR TITLE
Add some custom keycode for q1 and q2 types

### DIFF
--- a/src/keychron/q1/rev_0100.json
+++ b/src/keychron/q1/rev_0100.json
@@ -25,6 +25,10 @@
   "customKeycodes": [
     {"name": "Mission Control", "title": "Mission Control in macOS", "shortName": "Mission Control"},
     {"name": "Launch Pad", "title": "Launch Pad in macOS", "shortName": "Launch Pad"},
+    {"name": "Left Option", "title": "Left Option in macOS", "shortName": "Left Option"},
+    {"name": "Right Option", "title": "Right Option in macOS", "shortName": "Right Option"},
+    {"name": "Left Cmd", "title": "Left Command in macOS", "shortName": "Left Command"},
+    {"name": "Right Cmd", "title": "Right Command in macOS", "shortName": "Right Command"},
     {"name": "Task View", "title": "Task View in windows", "shortName": "Task View"},
     {"name": "File Explorer", "title": "File Explorer in windows", "shortName": "File Explorer"}
   ],

--- a/src/keychron/q1/rev_0101.json
+++ b/src/keychron/q1/rev_0101.json
@@ -25,6 +25,10 @@
   "customKeycodes": [
     {"name": "Mission Control", "title": "Mission Control in macOS", "shortName": "Mission Control"},
     {"name": "Launch Pad", "title": "Launch Pad in macOS", "shortName": "Launch Pad"},
+    {"name": "Left Option", "title": "Left Option in macOS", "shortName": "Left Option"},
+    {"name": "Right Option", "title": "Right Option in macOS", "shortName": "Right Option"},
+    {"name": "Left Cmd", "title": "Left Command in macOS", "shortName": "Left Command"},
+    {"name": "Right Cmd", "title": "Right Command in macOS", "shortName": "Right Command"},
     {"name": "Task View", "title": "Task View in windows", "shortName": "Task View"},
     {"name": "File Explorer", "title": "File Explorer in windows", "shortName": "File Explorer"}
   ],

--- a/src/keychron/q1/rev_0102.json
+++ b/src/keychron/q1/rev_0102.json
@@ -25,6 +25,10 @@
   "customKeycodes": [
     {"name": "Mission Control", "title": "Mission Control in macOS", "shortName": "Mission Control"},
     {"name": "Launch Pad", "title": "Launch Pad in macOS", "shortName": "Launch Pad"},
+    {"name": "Left Option", "title": "Left Option in macOS", "shortName": "Left Option"},
+    {"name": "Right Option", "title": "Right Option in macOS", "shortName": "Right Option"},
+    {"name": "Left Cmd", "title": "Left Command in macOS", "shortName": "Left Command"},
+    {"name": "Right Cmd", "title": "Right Command in macOS", "shortName": "Right Command"},
     {"name": "Task View", "title": "Task View in windows", "shortName": "Task View"},
     {"name": "File Explorer", "title": "File Explorer in windows", "shortName": "File Explorer"}
   ],

--- a/src/keychron/q2/rev_0110.json
+++ b/src/keychron/q2/rev_0110.json
@@ -25,6 +25,10 @@
   "customKeycodes": [
     {"name": "Mission Control", "title": "Mission Control in macOS", "shortName": "Mission Control"},
     {"name": "Launch Pad", "title": "Launch Pad in macOS", "shortName": "Launch Pad"},
+    {"name": "Left Option", "title": "Left Option in macOS", "shortName": "Left Option"},
+    {"name": "Right Option", "title": "Right Option in macOS", "shortName": "Right Option"},
+    {"name": "Left Cmd", "title": "Left Command in macOS", "shortName": "Left Command"},
+    {"name": "Right Cmd", "title": "Right Command in macOS", "shortName": "Right Command"},
     {"name": "Task View", "title": "Task View in windows", "shortName": "Task View"},
     {"name": "File Explorer", "title": "File Explorer in windows", "shortName": "File Explorer"}
   ],

--- a/src/keychron/q2/rev_0111.json
+++ b/src/keychron/q2/rev_0111.json
@@ -25,6 +25,10 @@
   "customKeycodes": [
     {"name": "Mission Control", "title": "Mission Control in macOS", "shortName": "Mission Control"},
     {"name": "Launch Pad", "title": "Launch Pad in macOS", "shortName": "Launch Pad"},
+    {"name": "Left Option", "title": "Left Option in macOS", "shortName": "Left Option"},
+    {"name": "Right Option", "title": "Right Option in macOS", "shortName": "Right Option"},
+    {"name": "Left Cmd", "title": "Left Command in macOS", "shortName": "Left Command"},
+    {"name": "Right Cmd", "title": "Right Command in macOS", "shortName": "Right Command"},
     {"name": "Task View", "title": "Task View in windows", "shortName": "Task View"},
     {"name": "File Explorer", "title": "File Explorer in windows", "shortName": "File Explorer"}
   ],

--- a/src/keychron/q2/rev_0112.json
+++ b/src/keychron/q2/rev_0112.json
@@ -25,6 +25,10 @@
   "customKeycodes": [
     {"name": "Mission Control", "title": "Mission Control in macOS", "shortName": "Mission Control"},
     {"name": "Launch Pad", "title": "Launch Pad in macOS", "shortName": "Launch Pad"},
+    {"name": "Left Option", "title": "Left Option in macOS", "shortName": "Left Option"},
+    {"name": "Right Option", "title": "Right Option in macOS", "shortName": "Right Option"},
+    {"name": "Left Cmd", "title": "Left Command in macOS", "shortName": "Left Command"},
+    {"name": "Right Cmd", "title": "Right Command in macOS", "shortName": "Right Command"},
     {"name": "Task View", "title": "Task View in windows", "shortName": "Task View"},
     {"name": "File Explorer", "title": "File Explorer in windows", "shortName": "File Explorer"}
   ],

--- a/src/keychron/q2/rev_0113.json
+++ b/src/keychron/q2/rev_0113.json
@@ -25,6 +25,10 @@
   "customKeycodes": [
     {"name": "Mission Control", "title": "Mission Control in macOS", "shortName": "Mission Control"},
     {"name": "Launch Pad", "title": "Launch Pad in macOS", "shortName": "Launch Pad"},
+    {"name": "Left Option", "title": "Left Option in macOS", "shortName": "Left Option"},
+    {"name": "Right Option", "title": "Right Option in macOS", "shortName": "Right Option"},
+    {"name": "Left Cmd", "title": "Left Command in macOS", "shortName": "Left Command"},
+    {"name": "Right Cmd", "title": "Right Command in macOS", "shortName": "Right Command"},
     {"name": "Task View", "title": "Task View in windows", "shortName": "Task View"},
     {"name": "File Explorer", "title": "File Explorer in windows", "shortName": "File Explorer"}
   ],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
- We added four custom keycodes for MAC operation system, so we can distinguish Windows and MAC easily.
-     KC_LOPT->Left Option.
-     KC_ROPT->Right Option.
-     KC_LCMD->Left Command.
-     KC_RCMD->Right Command.
## QMK Pull Request 

<!--- VIA support for new keyboards MUST be in QMK master already -->

<!--- Add link to QMK Pull Request here. -->

<!--- THIS IS MANDATORY. -->

<!--- IF THERE IS NO LINK TO SHOW VIA SUPPORT IS IN QMK MASTER ALREADY, -->
<!--- THIS PR WILL BE CLOSED IMMEDIATELY FOR WORKFLOW REASONS.  -->

## Checklist

<!--- Put an `x` in all the boxes that apply. -->

- [x] The VIA support for this keyboard is in QMK master already **(MANDATORY)**
- [x] The VIA definition follows the guide here: https://caniusevia.com/docs/layouts
- [x] I have tested this keyboard definition using VIA's "Design" tab.
- [x] I have tested this keyboard definition with firmware on a device.
- [x] I have assigned alpha keys and modifier keys with the correct colors.
- [x] The Vendor ID is not `0xFEED`
